### PR TITLE
Fix for the has-problems visitor

### DIFF
--- a/packages/visitors/src/has-problems.visitor.ts
+++ b/packages/visitors/src/has-problems.visitor.ts
@@ -7,7 +7,7 @@ export class HasProblemVisitor extends CombinedAllNodeVisitor {
   public problemsFound: boolean = false;
 
   visitNode(node: Node): void {
-    if (node._validationProblems.length > 0) {
+    if (node.getValidationProblems().length > 0) {
       this.problemsFound = true;
     }
   }


### PR DESCRIPTION
This visitor was not properly querying visited nodes for their problems.  Was this class never actually used in the old editor?  It's impossible to know.  :grin: 